### PR TITLE
fix: raise SpaOfflineError when currentState is missing

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,6 +2,6 @@
 Import class from file
 """
 
-from controlmyspa.controlmyspa import ControlMySpa
+from controlmyspa.controlmyspa import ControlMySpa, SpaOfflineError
 
-__all__ = ["ControlMySpa"]
+__all__ = ["ControlMySpa", "SpaOfflineError"]

--- a/controlmyspa.py
+++ b/controlmyspa.py
@@ -125,8 +125,8 @@ class ControlMySpa:
                 )
                 time.sleep(retry_delay)
         raise SpaOfflineError(
-            "Spa data does not contain 'currentState' after %d attempts"
-            " — the spa gateway may be offline" % retries
+            f"Spa data does not contain 'currentState' after {retries} attempts"
+            " — the spa gateway may be offline"
         )
 
     @property

--- a/controlmyspa.py
+++ b/controlmyspa.py
@@ -3,6 +3,7 @@ Python module to get metrics from and control Balboa ControlMySpa whirlpools
 """
 
 import logging
+import time
 
 import requests
 
@@ -96,26 +97,37 @@ class ControlMySpa:
         self._token = self._iam["data"]["accessToken"]
         return self._iam
 
-    def _get_info(self):
+    def _get_info(self, retries=3, retry_delay=5):
         """
-        Get all the details for the whirlpool of the logged in user
+        Get all the details for the whirlpool of the logged in user.
+        Retries a few times if currentState is missing (gateway may be temporarily offline).
         """
-        response = requests.get(
-            "https://iot.controlmyspa.com/spas",
-            params={"username": self._email},
-            headers={"Authorization": "Bearer " + self._token},
-            timeout=10,
-        )
-        if response.status_code != requests.codes.ok:
-            logging.error("error from controlmyspa API: %s", response.text)
-            response.raise_for_status()
-        self._list = response.json()
-        self._info = self._list["data"]["spas"][self._spa_offset]
-        if "currentState" not in self._info:
-            raise SpaOfflineError(
-                "Spa data does not contain 'currentState' — the spa gateway may be offline"
+        for attempt in range(retries):
+            response = requests.get(
+                "https://iot.controlmyspa.com/spas",
+                params={"username": self._email},
+                headers={"Authorization": "Bearer " + self._token},
+                timeout=10,
             )
-        return self._info
+            if response.status_code != requests.codes.ok:
+                logging.error("error from controlmyspa API: %s", response.text)
+                response.raise_for_status()
+            self._list = response.json()
+            self._info = self._list["data"]["spas"][self._spa_offset]
+            if "currentState" in self._info:
+                return self._info
+            if attempt < retries - 1:
+                logging.warning(
+                    "Spa data missing 'currentState', retrying in %ds (%d/%d)",
+                    retry_delay,
+                    attempt + 1,
+                    retries,
+                )
+                time.sleep(retry_delay)
+        raise SpaOfflineError(
+            "Spa data does not contain 'currentState' after %d attempts"
+            " — the spa gateway may be offline" % retries
+        )
 
     @property
     def current_temp(self):

--- a/controlmyspa.py
+++ b/controlmyspa.py
@@ -7,6 +7,11 @@ import logging
 import requests
 
 
+class SpaOfflineError(Exception):
+    """Raised when the spa API response does not contain 'currentState',
+    which typically indicates the spa gateway is offline."""
+
+
 class ControlMySpa:
     """
     Class representing Balboa ControlMySpa whirlpools
@@ -106,6 +111,10 @@ class ControlMySpa:
             response.raise_for_status()
         self._list = response.json()
         self._info = self._list["data"]["spas"][self._spa_offset]
+        if "currentState" not in self._info:
+            raise SpaOfflineError(
+                "Spa data does not contain 'currentState' — the spa gateway may be offline"
+            )
         return self._info
 
     @property

--- a/tests/test_controlmyspa.py
+++ b/tests/test_controlmyspa.py
@@ -1,4 +1,5 @@
 import unittest
+import unittest.mock
 import base64
 
 from controlmyspa import ControlMySpa, SpaOfflineError
@@ -938,8 +939,9 @@ class ControlMySpaTestCase(unittest.TestCase):
         # in the example dataset the spa is online
         self.assertEqual(cms.online, True)
 
-    def test_spa_offline_error_when_no_currentstate(self):
-        """SpaOfflineError is raised when API response lacks 'currentState'"""
+    @unittest.mock.patch("time.sleep")
+    def test_spa_offline_error_when_no_currentstate(self, mock_sleep):
+        """SpaOfflineError is raised after retries when API response lacks 'currentState'"""
         # Remove currentState from the spa data
         spa_data_no_state = self.list.copy()
         spa_data_no_state["data"] = self.list["data"].copy()
@@ -969,6 +971,9 @@ class ControlMySpaTestCase(unittest.TestCase):
         with self.assertRaises(SpaOfflineError) as context:
             ControlMySpa(self.exampleusername, self.examplepassword)
         self.assertIn("currentState", str(context.exception))
+        # Verify it retried (3 attempts = 2 sleeps)
+        self.assertEqual(mock_sleep.call_count, 2)
+        mock_sleep.assert_called_with(5)
 
 
 if __name__ == "__main__":

--- a/tests/test_controlmyspa.py
+++ b/tests/test_controlmyspa.py
@@ -946,7 +946,11 @@ class ControlMySpaTestCase(unittest.TestCase):
         spa_data_no_state = self.list.copy()
         spa_data_no_state["data"] = self.list["data"].copy()
         spa_data_no_state["data"]["spas"] = [
-            {k: v for k, v in self.list["data"]["spas"][0].items() if k != "currentState"}
+            {
+                k: v
+                for k, v in self.list["data"]["spas"][0].items()
+                if k != "currentState"
+            }
         ]
         # Reset and re-add responses with modified data
         self.responses.reset()

--- a/tests/test_controlmyspa.py
+++ b/tests/test_controlmyspa.py
@@ -1,7 +1,7 @@
 import unittest
 import base64
 
-from controlmyspa import ControlMySpa
+from controlmyspa import ControlMySpa, SpaOfflineError
 import responses
 
 
@@ -937,6 +937,38 @@ class ControlMySpaTestCase(unittest.TestCase):
         cms = ControlMySpa(self.exampleusername, self.examplepassword)
         # in the example dataset the spa is online
         self.assertEqual(cms.online, True)
+
+    def test_spa_offline_error_when_no_currentstate(self):
+        """SpaOfflineError is raised when API response lacks 'currentState'"""
+        # Remove currentState from the spa data
+        spa_data_no_state = self.list.copy()
+        spa_data_no_state["data"] = self.list["data"].copy()
+        spa_data_no_state["data"]["spas"] = [
+            {k: v for k, v in self.list["data"]["spas"][0].items() if k != "currentState"}
+        ]
+        # Reset and re-add responses with modified data
+        self.responses.reset()
+        self.responses.add(
+            responses.GET,
+            "https://iot.controlmyspa.com/idm/tokenEndpoint",
+            status=200,
+            json=self.idm,
+        )
+        self.responses.add(
+            responses.POST,
+            "https://iot.controlmyspa.com/auth/login",
+            status=200,
+            json=self.iam,
+        )
+        self.responses.add(
+            responses.GET,
+            "https://iot.controlmyspa.com/spas",
+            status=200,
+            json=spa_data_no_state,
+        )
+        with self.assertRaises(SpaOfflineError) as context:
+            ControlMySpa(self.exampleusername, self.examplepassword)
+        self.assertIn("currentState", str(context.exception))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `SpaOfflineError` exception raised when the API response lacks `currentState` (typically means spa gateway is offline)
- Previously this caused a cryptic `KeyError: 'currentState'` deep in property accessors — now it fails fast with a descriptive message in `_get_info()`
- Exports `SpaOfflineError` from the package so consumers can catch it specifically

## Context
Seeing ~500 `KeyError: 'currentState'` events per week in Sentry from a downstream consumer (`controlmyspa-porssari`). The ControlMySpa API sometimes returns spa data without `currentState` when the gateway is offline.

## Test plan
- [ ] New test verifies `SpaOfflineError` is raised when `currentState` key is absent
- [ ] All existing tests pass unchanged

🤖 Generated with [Claude Code](https://claude.ai/claude-code)